### PR TITLE
Improve theme toggle and fleet layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,13 +64,13 @@
       --space: clamp(12px, .9vw + 10px, 20px);
     }
     .light{
-      --bg:#f7f8fc;
-      --bg-elev:#ffffff;
+      --bg:#f8fafc;
+      --bg-elev:#f1f5f9;
       --panel:#ffffff;
-      --panel-2:#f2f5ff;
+      --panel-2:#e2e8f0;
       --text:#0f172a;
       --muted:#475569;
-      --card:#ffffffdd;
+      --card:#ffffff;
       --shadow: 0 10px 30px rgba(2,6,23,.08);
     }
 
@@ -83,6 +83,14 @@
       color:var(--text);
       line-height:1.5;
       scroll-behavior:smooth;
+      transition: background .3s ease, color .3s ease;
+    }
+
+    body.light{
+      background:
+        radial-gradient(1000px 600px at 10% -10%, #e0e7ff 0%, transparent 70%),
+        radial-gradient(800px 500px at 90% 0%, #c7d2fe 0%, transparent 70%),
+        var(--bg);
     }
     body.no-scroll{ overflow:hidden; }
 
@@ -150,7 +158,7 @@
 
     .nav-links{
       display:flex; align-items:center; min-width:0; gap:.3rem;
-      white-space:nowrap; overflow:hidden;
+      white-space:nowrap;
     }
     .nav-main{ display:flex; gap:.3rem; margin:0 auto; }
     .nav-main a{
@@ -280,14 +288,8 @@
     .avatar{ width:96px; height:96px; border-radius:50%; background: linear-gradient(145deg,#0b1226,#15224a); border:1px solid #22345c; display:grid; place-items:center; font-weight:900; }
 
     /* ---------- FLEET ---------- */
-    .fleet-wrap{ position:relative; }
-    .fleet{ display:grid; grid-auto-flow:column; gap:1rem; overflow-x:auto; padding-bottom:.4rem; scroll-snap-type:x mandatory; }
-    .fleet::-webkit-scrollbar{ height:8px; }
-    .fleet::-webkit-scrollbar-thumb{ background:#1e2b53; border-radius:8px; }
-    .fleet .car-card{ scroll-snap-align:start; min-width:260px; }
-
-    .arrow{ position:absolute; top:50%; transform:translateY(-50%); background:#0f172a; border:1px solid #1f2a44; border-radius:10px; cursor:pointer; display:flex; align-items:center; justify-content:center; width:44px; height:44px; }
-    .arrow.left{ left:-22px; } .arrow.right{ right:-22px; }
+    .fleet{ display:grid; grid-template-columns:repeat(3,1fr); gap:1rem; }
+    @media (max-width:980px){ .fleet{ grid-template-columns:1fr; } }
 
     /* ---------- REVIEWS ---------- */
     .reviews{ position:relative; overflow:hidden; }
@@ -425,7 +427,7 @@
           <a href="#contacts">Контакты</a>
         </div>
         <div class="nav-extra">
-          <button class="btn secondary" id="themeToggle" aria-label="Переключить тему" aria-pressed="false">Тема</button>
+          <button class="btn ghost" id="themeToggle" aria-label="Переключить тему" aria-pressed="false">Тема</button>
           <a class="btn" href="tel:+79001234567" aria-label="Позвонить в автошколу" title="+7 (900) 123-45-67">📞 <span class="phone-text">+7 (900) 123-45-67</span><span class="phone-short">45-67</span></a>
           <button class="btn" data-open-modal="enroll">Записаться</button>
         </div>
@@ -772,16 +774,12 @@
         <p class="muted reveal">Комфортные автомобили с кондиционером и камерами.</p>
       </div>
 
-      <div class="fleet-wrap">
-        <button class="arrow left" aria-label="Влево" id="fleetLeft">←</button>
-        <div class="fleet" id="fleetTrack">
-          <div class="card car-card reveal tilt"><h3>Kia Rio (АКПП)</h3><p class="muted">Парктроники, камера</p></div>
-          <div class="card car-card reveal tilt"><h3>Hyundai Solaris (МКПП)</h3><p class="muted">Отличная управляемость</p></div>
-          <div class="card car-card reveal tilt"><h3>Volkswagen Polo (АКПП)</h3><p class="muted">Комфортный салон</p></div>
-          <div class="card car-card reveal tilt"><h3>Skoda Rapid (МКПП)</h3><p class="muted">Экзаменационные маршруты</p></div>
-          <div class="card car-card reveal tilt"><h3>Renault Logan (МКПП)</h3><p class="muted">Надёжная классика</p></div>
-        </div>
-        <button class="arrow right" aria-label="Вправо" id="fleetRight">→</button>
+      <div class="fleet" id="fleetTrack">
+        <div class="card car-card reveal tilt"><h3>Kia Rio (АКПП)</h3><p class="muted">Парктроники, камера</p></div>
+        <div class="card car-card reveal tilt"><h3>Hyundai Solaris (МКПП)</h3><p class="muted">Отличная управляемость</p></div>
+        <div class="card car-card reveal tilt"><h3>Volkswagen Polo (АКПП)</h3><p class="muted">Комфортный салон</p></div>
+        <div class="card car-card reveal tilt"><h3>Skoda Rapid (МКПП)</h3><p class="muted">Экзаменационные маршруты</p></div>
+        <div class="card car-card reveal tilt"><h3>Renault Logan (МКПП)</h3><p class="muted">Надёжная классика</p></div>
       </div>
     </div>
   </section>
@@ -1342,13 +1340,8 @@
     };
     setInterval(()=> { idx = (idx+1)%slides; updateReviews(); }, 4500);
 
-    // ---------- FLEET SCROLLER ----------
-      const fleet = $('#fleetTrack');
-      $('#fleetLeft').addEventListener('click', ()=> fleet.scrollBy({left:-300, behavior:'smooth'}));
-      $('#fleetRight').addEventListener('click', ()=> fleet.scrollBy({left:300, behavior:'smooth'}));
-
-    // ---------- BACK TO TOP ----------
-    const toTop = $('#toTop');
+      // ---------- BACK TO TOP ----------
+      const toTop = $('#toTop');
     window.addEventListener('scroll', ()=>{
       toTop.style.display = window.scrollY > 600 ? 'inline-flex' : 'none';
     });


### PR DESCRIPTION
## Summary
- smooth light/dark theme with improved palette and gradients
- align navigation buttons and show theme toggle/call buttons
- show 3 cars per row in fleet and drop broken arrows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c14055a7f48323ab4534873368c440